### PR TITLE
Solving the encoding error when "config.yaml" is being opened in the code

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -23,7 +23,7 @@ class Constants:
         self.current_semester_id = self.semester.get(self.current_semester, '2020-秋')
 
     def _load_config_yaml(self) -> schemas.YamlConfig:
-        with open(os.path.join(self.app_path, 'config.yaml')) as fp:
+        with open(os.path.join(self.app_path, 'config.yaml'), encoding='utf-8') as fp:
             yaml_config = yaml.load(fp, Loader=yaml.BaseLoader)
         try:
             config = schemas.YamlConfig(


### PR DESCRIPTION
The code change in this pull request will help solve the following error that may pop up when trying to open and parse the "config.yaml" file:

`'gbk' codec can't decode byte 0xac in position 52: illegal multibyte sequence`

Problem solved by explicitly specifying the encoding to be "utf-8" in the code where this file is being opened.